### PR TITLE
Support reading slack webhook from secret

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,12 @@ Notification originates from Cloudwatch Alarm -> SNS -> Lambda
 
 ## Lambda
 
-Expects `SLACK_WEBHOOK_URL` env var to raise notification, if not supplied it will print payload that would be sent to Slack.
+Expects either `SLACK_WEBHOOK_URL` or `SLACK_WEBHOOK_SECRET` env var to raise notifications:
+
+* `SLACK_WEBHOOK_URL` - Webook URL value
+* `SLACK_WEBHOOK_SECRET` - AWS SecretsManager Id containing webook URL as plain text.
+
+If not supplied it will print payload that would be sent to Slack. If both supplied `SLACK_WEBHOOK_URL` takes precedence.
 
 Parses incoming SNS message and POSTs to above webhook url.
 
@@ -22,17 +27,21 @@ Terraform creates:
 * SNS Topic
 * SNS Topic subscription to Lambda
 * SNS Topic policy to allow Cloudwatch Alarms to publish
+* if `SLACK_WEBHOOK_SECRET` provided:
+  * `AWS Parameters and Secrets Lambda Extension` layer is added
+  * Permissions for Lambda execution policy to read secret
 
 ### Variables
 
-| Variable          | Description                                              | Default    |
-| ----------------- | -------------------------------------------------------- | ---------- |
-| s3_bucket         | S3 bucket containing cloudwatch-to-slack Lambda function |            |
-| s3_key            | S3 key for cloudwatch-to-slack Lambda function           |            |
-| sns_topic_arn     | ARN of topic that will trigger Lambda                    |            |
-| prefix            | Prefix for services                                      |            |
-| slack_webhook_url | Slack webhook URL to call                                |            |
-| runtime           | Python runtime to use for lambda                         | python3.11 |
+| Variable             | Description                                                            | Default    |
+| -------------------- | ---------------------------------------------------------------------- | ---------- |
+| s3_bucket            | S3 bucket containing cloudwatch-to-slack Lambda function               |            |
+| s3_key               | S3 key for cloudwatch-to-slack Lambda function                         |            |
+| sns_topic_arn        | ARN of topic that will trigger Lambda                                  |            |
+| prefix               | Prefix for services                                                    |            |
+| slack_webhook_url    | Slack webhook URL to call (optional)                                   |            |
+| slack_webhook_secret | AWS SecretsManager secret storing Slack webhook URL to call (optional) |            |
+| runtime              | Python runtime to use for lambda                                       | python3.11 |
 
 ### Outputs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.31.0
+requests==2.32.3

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,6 +11,13 @@ variable "s3_key" {
 variable "slack_webhook_url" {
   description = "Slack webhook URL to call"
   type        = string
+  default     = ""
+}
+
+variable "slack_webhook_secret" {
+  description = "SecretsManager secret containing slack webhook URL to call"
+  type        = string
+  default     = ""
 }
 
 variable "runtime" {
@@ -37,4 +44,13 @@ variable "account_id" {
 variable "region" {
   description = "AWS region"
   type        = string
+}
+
+locals {
+  env_candidates = {
+    SLACK_WEBHOOK_URL    = var.slack_webhook_url
+    SLACK_WEBHOOK_SECRET = var.slack_webhook_secret
+  }
+
+  env_vars = { for k, v in local.env_candidates : k => v if v != "" }
 }


### PR DESCRIPTION
Rather than providing a webhook url directly via `SLACK_WEBHOOK_URL`, support specifying a secret id via `SLACK_WEBHOOK_SECRET` 

If provided it will (as per [AWS documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_lambda.html)):
* Set env var `SLACK_WEBHOOK_SECRET`
* Add Lambda layer for reading secrets
* Give execution role appropriate access to read secret

Lambda code updated to:
* Use `SLACK_WEBHOOK_URL` if provided. Else
* Use Lambda secret extension to read secret id from `SLACK_WEBHOOK_SECRET` via HTTP request.